### PR TITLE
feat: enhance OptionsButton with a opt in description

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.vs/
 .vscode/
 obj/
 bin/

--- a/TowerFall.FortRise.mm/Core/Module/ModuleSettings.cs
+++ b/TowerFall.FortRise.mm/Core/Module/ModuleSettings.cs
@@ -1,9 +1,9 @@
-using System;
-using System.Collections.Generic;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Input;
 using Monocle;
 using MonoMod.Utils;
+using System;
+using System.Collections.Generic;
 using TowerFall;
 
 namespace FortRise;
@@ -12,13 +12,20 @@ public interface ISettingsCreate
 {
     void CreateOnOff(string name, bool initialValue, Action<bool> onPressed);
     void CreateOnOff(string name, bool initialValue, Action<bool> onPressed, bool restartRequired);
+    void CreateOnOff(string name, bool initialValue, Action<bool> onPressed, string description = "");
+    void CreateOnOff(string name, bool initialValue, Action<bool> onPressed, bool restartRequired, string description = "");
     void CreateOptions(string name, string initialValue, string[] selections, Action<(string, int)> onSelect);
+    void CreateOptions(string name, string initialValue, string[] selections, Action<(string, int)> onSelect, string description = "");
     void CreateButton(string name, Action onPressed);
+    void CreateButton(string name, Action onPressed, string description = "");
     void CreateNumber(string name, int initialValue, Action<int> onChanged, int min = 0, int max = 10, int step = 1);
+    void CreateNumber(string name, int initialValue, Action<int> onChanged, string description, int min = 0, int max = 10, int step = 1);
     [Obsolete("Use 'CreateInput' without the TextContainer.InputText")]
     void CreateInput(string name, string initialValue, Action<string> onInput, TextContainer.InputText.InputBehavior inputBehavior = TextContainer.InputText.InputBehavior.None);
     void CreateInput(string name, string initialValue, Action<string> onInput, InputBehavior inputBehavior = InputBehavior.None);
     void CreateInput(string name, string initialValue, Action<string> onInput, int playerIndex, InputBehavior inputBehavior = InputBehavior.None);
+    void CreateInput(string name, string initialValue, Action<string> onInput, string description = "", InputBehavior inputBehavior = InputBehavior.None);
+    void CreateInput(string name, string initialValue, Action<string> onInput, int playerIndex, string description = "", InputBehavior inputBehavior = InputBehavior.None);
     void CreateGamepadInputOptions(string name, int playerIndex, Buttons[] buttons, Action<Buttons[]> onInput);
     void CreateKeyboardInputOptions(string name, Keys[] buttons, Action<Keys[]> onInput);
     void CreateCustomOptions(Func<OptionsButton> onCreate);
@@ -46,6 +53,12 @@ internal sealed class OptionsCreate(MainMenu menu, List<OptionsButton> buttons) 
         OptionsButton.Add(optionButtons);
     }
 
+    public void CreateButton(string name, Action onPressed, string description = "")
+    {
+        CreateButton(name, onPressed);
+        DescribeLastEntry(description);
+    }
+
     public void CreateInput(string name, string initialValue, Action<string> onInput, TextContainer.InputText.InputBehavior inputBehavior = TextContainer.InputText.InputBehavior.None)
     {
         CreateInput(name, initialValue, onInput, -1, (InputBehavior)inputBehavior);
@@ -55,7 +68,7 @@ internal sealed class OptionsCreate(MainMenu menu, List<OptionsButton> buttons) 
     {
         CreateInput(name, initialValue, onInput, -1, inputBehavior);
     }
-    
+
     public void CreateInput(string name, string initialValue, Action<string> onInput, int playerIndex, InputBehavior inputBehavior = InputBehavior.None)
     {
         string title = name.ToUpperInvariant();
@@ -65,7 +78,7 @@ internal sealed class OptionsCreate(MainMenu menu, List<OptionsButton> buttons) 
         var dynSelf = DynamicData.For(optionButtons);
         initialValue ??= "";
         dynSelf.Set("value", initialValue); 
-        
+
         optionButtons.SetCallbacks(() =>
         {
             if (inputBehavior == InputBehavior.Sensitive)
@@ -98,6 +111,18 @@ internal sealed class OptionsCreate(MainMenu menu, List<OptionsButton> buttons) 
         OptionsButton.Add(optionButtons);
     }
 
+    public void CreateInput(string name, string initialValue, Action<string> onInput, string description = "", InputBehavior inputBehavior = InputBehavior.None)
+    {
+        CreateInput(name, initialValue, onInput, -1, inputBehavior);
+        DescribeLastEntry(description);
+    }
+
+    public void CreateInput(string name, string initialValue, Action<string> onInput, int playerIndex, string description = "", InputBehavior inputBehavior = InputBehavior.None)
+    {
+        CreateInput(name, initialValue, onInput, playerIndex, inputBehavior);
+        DescribeLastEntry(description);
+    }
+
     public void CreateNumber(string name, int initialValue, Action<int> onChanged, int min = 0, int max = 10, int step = 1)
     {
         string title = name.ToUpperInvariant();
@@ -106,7 +131,6 @@ internal sealed class OptionsCreate(MainMenu menu, List<OptionsButton> buttons) 
         // HACK: Option button does not have a value.
         var dynSelf = DynamicData.For(optionButtons);
         dynSelf.Set("value", initialValue); 
-        
         optionButtons.SetCallbacks(() =>
         {
             int value = dynSelf.Get<int>("value");
@@ -131,9 +155,27 @@ internal sealed class OptionsCreate(MainMenu menu, List<OptionsButton> buttons) 
         OptionsButton.Add(optionButtons);
     }
 
+    public void CreateNumber(string name, int initialValue, Action<int> onChanged, string description, int min = 0, int max = 10, int step = 1)
+    {
+        CreateNumber(name, initialValue, onChanged, min, max, step);
+        DescribeLastEntry(description);
+    }
+
     public void CreateOnOff(string name, bool initialValue, Action<bool> onPressed)
     {
         CreateOnOff(name, initialValue, onPressed, false);
+    }
+
+    public void CreateOnOff(string name, bool initialValue, Action<bool> onPressed, string description = "")
+    {
+        CreateOnOff(name, initialValue, onPressed, false);
+        DescribeLastEntry(description);
+    }
+
+    public void CreateOnOff(string name, bool initialValue, Action<bool> onPressed, bool restartRequired, string description = "")
+    {
+        CreateOnOff(name, initialValue, onPressed, restartRequired);
+        DescribeLastEntry(description);
     }
 
     public void CreateOnOff(string name, bool initialValue, Action<bool> onPressed, bool restartRequired)
@@ -144,7 +186,7 @@ internal sealed class OptionsCreate(MainMenu menu, List<OptionsButton> buttons) 
         // HACK: Option button does not have a value.
         var dynSelf = DynamicData.For(optionButtons);
         dynSelf.Set("value", initialValue); 
-        
+
         optionButtons.SetCallbacks(() => optionButtons.State = BoolToString(dynSelf.Get<bool>("value")), null, null, onConfirm: () =>
         {
             var value = dynSelf.Get<bool>("value");
@@ -235,7 +277,21 @@ internal sealed class OptionsCreate(MainMenu menu, List<OptionsButton> buttons) 
         OptionsButton.Add(optionButtons);
     }
 
+    public void CreateOptions(string name, string initialValue, string[] selections, Action<(string, int)> onSelect, string description = "")
+    {
+        CreateOptions(name, initialValue, selections, onSelect);
+        DescribeLastEntry(description);
+    }
+
     public void Refresh() { }
+
+    private void DescribeLastEntry(string description)
+    {
+        if (!string.IsNullOrWhiteSpace(description) && OptionsButton.Count > 0)
+        {
+            OptionsButton[OptionsButton.Count - 1].SetDescription(description);
+        }
+    }
 
     private static string BoolToString(bool value)
     {

--- a/TowerFall.FortRise.mm/Core/UI/OptionDescriptionBox.cs
+++ b/TowerFall.FortRise.mm/Core/UI/OptionDescriptionBox.cs
@@ -1,0 +1,123 @@
+using Microsoft.Xna.Framework;
+using Monocle;
+using System;
+using System.Collections.Generic;
+using TowerFall;
+
+namespace FortRise;
+
+public sealed class OptionDescriptionBox : MenuItem
+{
+    private const float MaxTextWidth = 260f;
+    private const float PaddingX = 8f;
+    private const float PaddingY = 6f;
+    private const float LineHeight = 10f;
+    private const float BottomMargin = 6f;
+    private const float CenterX = 160f;
+    private const float ScreenHeight = 240f;
+
+    private readonly List<OptionsButton> buttons;
+    private string currentText;
+    private string[] lines = [];
+    private float panelWidth;
+
+    public OptionDescriptionBox(List<OptionsButton> buttons) : base(Vector2.Zero)
+    {
+        this.buttons = buttons;
+        Depth = -100;
+    }
+
+    public override void TweenIn() { }
+    public override void TweenOut() { }
+    protected override void OnSelect() { }
+    protected override void OnDeselect() { }
+    protected override void OnConfirm() { }
+
+    public override void Render()
+    {
+        base.Render();
+
+        var description = FindSelectedDescription();
+        if (string.IsNullOrEmpty(description))
+        {
+            return;
+        }
+
+        if (description != currentText)
+        {
+            currentText = description;
+            lines = WrapText(description.ToUpperInvariant(), MaxTextWidth);
+            panelWidth = 0f;
+            foreach (var line in lines)
+            {
+                panelWidth = Math.Max(panelWidth, TFGame.Font.MeasureString(line).X);
+            }
+            panelWidth += PaddingX * 2f;
+        }
+
+        if (lines.Length == 0)
+        {
+            return;
+        }
+
+        float cameraY = MainMenu != null ? MainMenu.UILayer.Camera.Y : 0f;
+        float panelHeight = lines.Length * LineHeight + PaddingY * 2f;
+        float top = cameraY + ScreenHeight - BottomMargin - panelHeight;
+        float left = CenterX - panelWidth / 2f;
+
+        Draw.Rect(left - 1f, top - 1f, panelWidth + 2f, panelHeight + 2f, Color.White * 0.5f);
+        Draw.Rect(left, top, panelWidth, panelHeight, Color.Black * 0.9f);
+
+        for (int i = 0; i < lines.Length; i++)
+        {
+            Draw.OutlineTextCentered(
+                TFGame.Font,
+                lines[i],
+                new Vector2(CenterX, top + PaddingY + i * LineHeight + LineHeight / 2f),
+                Color.White,
+                Color.Black);
+        }
+    }
+
+    private string FindSelectedDescription()
+    {
+        foreach (var button in buttons)
+        {
+            if (button.Selected)
+            {
+                return button.GetDescription();
+            }
+        }
+
+        return null;
+    }
+
+    private static string[] WrapText(string text, float maxWidth)
+    {
+        var result = new List<string>();
+        foreach (var paragraph in text.Split('\n'))
+        {
+            var current = "";
+            foreach (var word in paragraph.Split(' ', StringSplitOptions.RemoveEmptyEntries))
+            {
+                var wordCandidate = current.Length == 0 ? word : current + " " + word;
+                if (current.Length > 0 && TFGame.Font.MeasureString(wordCandidate).X > maxWidth)
+                {
+                    result.Add(current);
+                    current = word;
+                }
+                else
+                {
+                    current = wordCandidate;
+                }
+            }
+
+            if (current.Length > 0)
+            {
+                result.Add(current);
+            }
+        }
+
+        return result.ToArray();
+    }
+}

--- a/TowerFall.FortRise.mm/Core/UI/OptionsButtonDescription.cs
+++ b/TowerFall.FortRise.mm/Core/UI/OptionsButtonDescription.cs
@@ -1,0 +1,19 @@
+using MonoMod.Utils;
+using TowerFall;
+
+namespace FortRise;
+
+public static class OptionsButtonDescription
+{
+    private const string Key = "fortrise_description";
+
+    public static void SetDescription(this OptionsButton button, string description)
+    {
+        DynamicData.For(button).Set(Key, description);
+    }
+
+    public static string GetDescription(this OptionsButton button)
+    {
+        return DynamicData.For(button).TryGet<string>(Key, out var description) ? description : null;
+    }
+}

--- a/TowerFall.FortRise.mm/Patches/MainMenu.cs
+++ b/TowerFall.FortRise.mm/Patches/MainMenu.cs
@@ -554,6 +554,15 @@ namespace TowerFall
 
             Add(buttons);
             MaxUICameraY = num;
+
+            foreach (var button in buttons)
+            {
+                if (!string.IsNullOrEmpty(button.GetDescription()))
+                {
+                    Add(new OptionDescriptionBox(buttons));
+                    break;
+                }
+            }
         }
 
         [MonoModIgnore]


### PR DESCRIPTION
Add a description to option button. 
This is not mandatory and the old behaviour is kept for no breaking changes , mod made for a previous FortRise version work.
I also used a custom box for it but if you have a better solution, tell me.

The result look like

<img width="956" height="706" alt="image" src="https://github.com/user-attachments/assets/6b8b2277-b84e-42b3-b8b0-ea906a694195" />
